### PR TITLE
Добавляет только по 1 товару, если уже в корзине

### DIFF
--- a/assets/plugins/commerce/src/Carts/SimpleCart.php
+++ b/assets/plugins/commerce/src/Carts/SimpleCart.php
@@ -90,7 +90,8 @@ class SimpleCart implements \Commerce\Interfaces\Cart
 
             foreach ($this->items as $row => $item) {
                 if ($item['hash'] == $new['hash']) {
-                    $this->update($row, ['count' => $item['count'] + (!empty($new['count']) ? $new['count'] : 1)]);
+                    //$this->update($row, ['count' => $item['count'] + (!empty($new['count']) ? $new['count'] : 1)]);
+                    $this->update($row, ['count' => $item['count'] + (!empty($new['count']) && is_numeric($new['count']) ? $new['count'] : 1)]);
                     return $row;
                 }
             }


### PR DESCRIPTION
При изначальном добавлении товара в корзину добавляет столько, сколько указано в параметре count/data-count. А вот при последующем добавлении данный параметр уже не учитывает и плюсует только по одному.