### PR TITLE
fix payment process

### DIFF
--- a/assets/plugins/commerce/src/Commerce.php
+++ b/assets/plugins/commerce/src/Commerce.php
@@ -443,7 +443,7 @@ class Commerce
             }
         }
 
-        if (preg_match('/commerce\/([a-z-_]+?)\/(payment-[a-z-]+?)$/', $route, $parts)) {
+        if (preg_match('/commerce\/([a-z-_]+?)\/(payment-[a-z-]+?)\/?$/', $route, $parts)) {
             try {
                 $payment = $this->getPayment($parts[1]);
             } catch (\Exception $e) {


### PR DESCRIPTION
https://github.com/mnoskov/commerce-payment-sberbank/blob/master/assets/plugins/commerce/src/Payments/SberbankPayment.php#L77 - в результате в $route попадает "commerce/sberbank/payment-process/" и выражение не выполняется из-за слэша в конце. Поэтому в регулярке нужно это учесть.