### PR TITLE
fix loadOrder($id) and then getCart() doesn't load order cart if called more than once

### DIFF
--- a/assets/plugins/commerce/src/Processors/OrdersProcessor.php
+++ b/assets/plugins/commerce/src/Processors/OrdersProcessor.php
@@ -484,6 +484,7 @@ class OrdersProcessor implements \Commerce\Interfaces\Processor
             $this->order = $this->modx->db->getRow($query);
             $this->order['fields'] = json_decode($this->order['fields'], true);
             $this->order_id = $this->order['id'];
+            $this->cart = null;
             return $this->order;
         }
 


### PR DESCRIPTION
Если загружать в процессор разные заказы, то корзина не меняется.